### PR TITLE
* Fixed issue with setup script paths.  It didn't include 'SetupScrip…

### DIFF
--- a/DropDatabase.ps1
+++ b/DropDatabase.ps1
@@ -51,13 +51,13 @@ function DbExists{
 		$exists = ExecuteScalar $conn "SELECT TOP 1 * FROM master.dbo.sysdatabases WHERE name = '$dbname'"
 		
 		# did we get Null?  If so, the database doesn't exist.
-		if(!$exists)
+		if($exists)
 		{
-			return $false
+			return $true
 		}
 		else
 		{
-			return $true	
+			return $false
 		}
 	}
 	catch 

--- a/SetupDevMachine.ps1
+++ b/SetupDevMachine.ps1
@@ -58,13 +58,13 @@ function DbExists{
 		$exists = ExecuteScalar $conn "SELECT TOP 1 * FROM master.dbo.sysdatabases WHERE name = '$dbname'"
 		
 		# did we get Null?  If so, the database doesn't exist.
-		if(!$exists)
+		if($exists)
 		{
-			return $false
+			return $true
 		}
 		else
 		{
-			return $true	
+			return $false
 		}
 	}
 	catch 


### PR DESCRIPTION
* Fixed issue with setup script paths.  It didn't include 'SetupScripts' in the path.

* Refactored to use common 'RunSetupScript' function

* Added '-recreate' command line argument to allow user to recreate the database.  This is useful if the script failed for some reason and left the database in an odd state

* Added try...catch blocks

* Refactored various functions to take a Connection object.  This allows us to properly close the connection if something goes wrong.

* Changed the query that looks for the CodeCamp database to use ExecuteNonScalar.  This way, we don't have to loop on results.  The SQL query will directly look for our database.

* Added 'DropDatabase.ps1' Powershell script.  This drops the CodeCamp database, if it exists.  Mostly just for cleanup.