### PR TITLE
Fixes issue #41 - Editing a sponsor required image upload.

### DIFF
--- a/CC.Service.Webhost/Services/CodeCampService.cs
+++ b/CC.Service.Webhost/Services/CodeCampService.cs
@@ -382,8 +382,12 @@ namespace CC.Service.Webhost.CodeCampSvc
                 s.Description = sponsor.Description;
                 s.WebsiteUrl = sponsor.WebsiteUrl;
                 s.SponsorshipLevel = sponsor.SponsorshipLevel;
-                //s.ImageUrl = sponsor.ImageUrl;
-                s.Image = sponsor.Image;
+
+                // Don't update the image if one wasn't supplied.
+                if (sponsor.Image != null && sponsor.Image.Length > 0)
+                {
+                    s.Image = sponsor.Image;
+                }
 
                 db.SaveChanges();
             }

--- a/CC.UI.Webhost/CC.UI.Webhost.csproj
+++ b/CC.UI.Webhost/CC.UI.Webhost.csproj
@@ -310,6 +310,7 @@
     <Compile Include="Models\Volunteer.cs" />
     <Compile Include="Models\VolunteerTask.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Utilities\ImageUtils.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Content\Avatar\2014.jpg" />

--- a/CC.UI.Webhost/Controllers/HomeController.cs
+++ b/CC.UI.Webhost/Controllers/HomeController.cs
@@ -11,6 +11,7 @@ namespace CC.UI.Webhost.Controllers
 
     using CC.UI.Webhost.Models;
     using System.Web.UI;
+    using OCC.UI.Webhost.Utilities;
 
     [RequireHttps]
     public class HomeController : BaseController
@@ -298,7 +299,7 @@ namespace CC.UI.Webhost.Controllers
                                   Description = sponsor.Description,
                                   SponsorshipLevel = sponsor.SponsorshipLevel,
                                   WebsiteUrl = sponsor.WebsiteUrl,
-                                  Logo = sponsor.Image == null ? null : new Infrastructure.WebImageOCC(sponsor.Image)
+                                  Logo = ImageUtils.ImageFromBytes(sponsor.Image)
                               });
 
             return View(model);

--- a/CC.UI.Webhost/Controllers/MetroTileController.cs
+++ b/CC.UI.Webhost/Controllers/MetroTileController.cs
@@ -5,6 +5,7 @@ using CC.Service.Webhost.CodeCampSvc;
 using CC.UI.Webhost.Infrastructure;
 using CC.UI.Webhost.Models;
 using CC.Service.Webhost.Services;
+using OCC.UI.Webhost.Utilities;
 
 namespace CC.UI.Webhost.Controllers
 {
@@ -113,14 +114,10 @@ namespace CC.UI.Webhost.Controllers
 
             foreach (var sponsor in sponsors)
             {
-                if (!string.IsNullOrEmpty(sponsor.Name) && sponsor.Image != null)
+                MetroTileImage sponsorTile = SponsorToDoubleMetroTile(sponsor);
+                if (sponsorTile != null)
                 {
-                    tileViewModel.MetroTileIcons.Add(new MetroTileImage(new Infrastructure.WebImageOCC(sponsor.Image))
-                    {
-                        AltText = sponsor.Name,
-                        Title = string.Format("{0} ({1} sponsor)", sponsor.Name, sponsor.SponsorshipLevel.Replace("sponsor", String.Empty)),
-                        AnchorTagUri = sponsor.WebsiteUrl
-                    });
+                    tileViewModel.MetroTileIcons.Add(sponsorTile);
                 }
             }
             tileViewModel.MetroTileIcons.Shuffle();
@@ -327,5 +324,30 @@ namespace CC.UI.Webhost.Controllers
 
             return PartialView("_TwitterMetroTile", twitterTileViewModel);
         }
+
+        #region Private Helpers
+
+        private MetroTileImage SponsorToDoubleMetroTile(Service.Webhost.Services.Sponsor sponsor)
+        {
+            // Only create a tile if the sponsor has a Name AND an image.
+            // Also, if the sponsor image is corrupted for some reason, don't add it.
+            WebImageOCC image = ImageUtils.ImageFromBytes(sponsor.Image);
+
+            if (!string.IsNullOrEmpty(sponsor.Name) && image != null)
+            {
+                return new MetroTileImage(image)
+                {
+                    AltText = sponsor.Name,
+                    Title = string.Format("{0} ({1} sponsor)", sponsor.Name, sponsor.SponsorshipLevel.Replace("sponsor", String.Empty)),
+                    AnchorTagUri = sponsor.WebsiteUrl
+                };
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        #endregion
     }
 }

--- a/CC.UI.Webhost/Controllers/SponsorController.cs
+++ b/CC.UI.Webhost/Controllers/SponsorController.cs
@@ -8,6 +8,8 @@ namespace CC.UI.Webhost.Controllers
     using System.Web;
     using System.Web.Mvc;
     using CC.UI.Webhost.Models;
+    using OCC.UI.Webhost.Utilities;
+    using System.Linq;
 
     public class SponsorController : BaseController
     {
@@ -21,21 +23,7 @@ namespace CC.UI.Webhost.Controllers
         public ActionResult Index(int eventid)
         {
             var sponsors = service.GetSponsors(eventid);
-
-            List<Sponsor> model = new List<Sponsor>();
-
-            foreach (var sponsor in sponsors)
-                model.Add(new Sponsor()
-                {
-                    ID = sponsor.ID,
-                    EventID = sponsor.EventID,
-                    Name = sponsor.Name,
-                    Description = sponsor.Description,
-                    SponsorshipLevel = sponsor.SponsorshipLevel,
-                    WebsiteUrl = sponsor.WebsiteUrl,
-                    Logo = sponsor.Image == null ? null : new Infrastructure.WebImageOCC(sponsor.Image),
-                });
-
+            List<Sponsor> model = sponsors.Select(ServiceToWebHostSponsor).ToList();
             return View(model);
         }
 
@@ -103,18 +91,7 @@ namespace CC.UI.Webhost.Controllers
         public ActionResult Edit(int id)
         {
             var sponsor = service.GetSponsor(id);
-
-            Sponsor model = new Sponsor()
-            {
-                ID = sponsor.ID,
-                EventID = sponsor.EventID,
-                Name = sponsor.Name,
-                Description = sponsor.Description,
-                SponsorshipLevel = sponsor.SponsorshipLevel,
-                WebsiteUrl = sponsor.WebsiteUrl,
-                Logo = sponsor.Image == null ? null : new Infrastructure.WebImageOCC(sponsor.Image),
-            };
-
+            Sponsor model = ServiceToWebHostSponsor(sponsor);
             return View(model);
         }
 
@@ -176,6 +153,8 @@ namespace CC.UI.Webhost.Controllers
             }
         }
 
+        #region Private Helpers
+
         private byte[] ConvertToByes(HttpPostedFileBase image)
         {
             byte[] imageBytes = null;
@@ -183,5 +162,23 @@ namespace CC.UI.Webhost.Controllers
             imageBytes = reader.ReadBytes((int)image.ContentLength);
             return imageBytes;
         }
+
+        // Leaving fully qualified names here since it's kind of confusing having the two sponsor classes
+        // named the same.  This way, it's clear.
+        private CC.UI.Webhost.Models.Sponsor ServiceToWebHostSponsor(Service.Webhost.Services.Sponsor serviceSponsor)
+        {
+            return new CC.UI.Webhost.Models.Sponsor()
+            {
+                ID = serviceSponsor.ID,
+                EventID = serviceSponsor.EventID,
+                Name = serviceSponsor.Name,
+                Description = serviceSponsor.Description,
+                SponsorshipLevel = serviceSponsor.SponsorshipLevel,
+                WebsiteUrl = serviceSponsor.WebsiteUrl,
+                Logo = ImageUtils.ImageFromBytes(serviceSponsor.Image),
+            };
+        }
+
+        #endregion
     }
 }

--- a/CC.UI.Webhost/Utilities/ImageUtils.cs
+++ b/CC.UI.Webhost/Utilities/ImageUtils.cs
@@ -1,0 +1,38 @@
+﻿using CC.UI.Webhost.Infrastructure;
+
+namespace OCC.UI.Webhost.Utilities
+{
+    /// <summary>
+    /// Helper functions to deal with images.
+    /// </summary>
+    public static class ImageUtils
+    {
+        /// <summary>
+        /// Creates a WebImageOCC from a Byte Array.
+        /// </summary>
+        /// <param name="imageBytes">Byte array containing the image data.</param>
+        /// <returns>WebImageOCC created from the image data, or null if no data was present.</returns>
+        /// <exception cref=""
+        public static WebImageOCC ImageFromBytes(byte[] imageBytes)
+        {
+            // If there isn't any data, just return null
+            if (imageBytes == null || imageBytes.Length == 0)
+            {
+                return null;
+            }
+
+            try
+            {
+                return new WebImageOCC(imageBytes);
+            }
+            catch
+            {
+                // Just eat the exception and return Null for now.
+                // It would probably be better to throw some kind of "corrupt image data"
+                // exception and then setup logging to notify us of that, but for now this is
+                // good enough I think.
+                return null;
+            }
+        }
+    }
+}


### PR DESCRIPTION
* Added ImageUtils class to take care of dealing with nulls and corrupted image data.

* Updated CodeCampService to not update the sponsor image if one wasn't supplied.  This prevents the image from being accidentally deleted.

* Updated some controllers to use the ImageUtils.ImageFromBytes helper function.

* Moved some Sponsor mapping code into helper functions so that we reuse it.  Also, converted a loop to be a single LINQ Select statement using the helper function.

* Moved the code that creates Metro tiles for the Sponsors into a private helper function.