### PR TITLE
Summary of Changes:

### DIFF
--- a/CC.Data.Database/dbo/Tables/People.sql
+++ b/CC.Data.Database/dbo/Tables/People.sql
@@ -13,7 +13,8 @@
     [IsAdmin]      BIT             NOT NULL,
     [Location]     NVARCHAR (100)  NULL,
     [TShirtSize]   INT             NULL,
-    [LoginProvider] NVARCHAR(128) NULL, 
-    CONSTRAINT [PK__People__3214EC2714FCD345] PRIMARY KEY CLUSTERED ([ID] ASC)
+    [LoginProvider] NVARCHAR(128) NULL,
+	[Image]         VARBINARY (MAX) NULL,
+     CONSTRAINT [PK__People__3214EC2714FCD345] PRIMARY KEY CLUSTERED ([ID] ASC)
 );
 

--- a/CC.Data/Person.cs
+++ b/CC.Data/Person.cs
@@ -37,6 +37,8 @@
         [StringLength(500)]
         public string ImageUrl { get; set; }
 
+        public byte[] Image { get; set; }
+        
         [StringLength(100)]
         public string Location { get; set; }
 

--- a/CC.Service.Webhost/Repositories/PersonRepository.cs
+++ b/CC.Service.Webhost/Repositories/PersonRepository.cs
@@ -130,6 +130,7 @@ namespace CC.Service.Webhost.Repositories
             p.Blog = person.Blog;
             p.Twitter = person.Twitter;
             p.ImageUrl = person.ImageUrl;
+            p.Image = person.Image;
             p.Location = person.Location;
             p.TShirtSize = person.TShirtSize;
             p.LoginProvider = person.LoginProvider;

--- a/CC.Service.Webhost/Services/Attendee.cs
+++ b/CC.Service.Webhost/Services/Attendee.cs
@@ -42,6 +42,9 @@
         [DataMember]
         public IList<Session> Agenda { get; set; }
 
+        [DataMember]
+        public byte[] Image { get; set; }
+
         public Attendee()
         {
             Agenda = new List<Session>();

--- a/CC.Service.Webhost/Services/CodeCampService.cs
+++ b/CC.Service.Webhost/Services/CodeCampService.cs
@@ -827,7 +827,8 @@ namespace CC.Service.Webhost.CodeCampSvc
                     Website = string.IsNullOrEmpty(s.Website) ? string.Empty : s.Website,
                     Blog = string.IsNullOrEmpty(s.Blog) ? string.Empty : s.Blog,
                     Twitter = string.IsNullOrEmpty(s.Twitter) ? string.Empty : s.Twitter,
-                    ImageUrl = s.ImageUrl
+                    ImageUrl = s.ImageUrl,
+                    Image = s.Image
                 };
 
                 foreach (var session in s.Sessions)

--- a/CC.Service.Webhost/Services/Person.cs
+++ b/CC.Service.Webhost/Services/Person.cs
@@ -50,5 +50,8 @@
 
         [DataMember]
         public string LoginProvider { get; set; }
+
+        [DataMember]
+        public byte[] Image { get; set; }
     }
 }

--- a/CC.Service.Webhost/Services/Session.cs
+++ b/CC.Service.Webhost/Services/Session.cs
@@ -43,6 +43,9 @@
         public string ImageUrl { get; set; }
 
         [DataMember]
+        public byte[] Image { get; set; }
+
+        [DataMember]
         public DateTime? StartTime { get; set; }
 
         [DataMember]

--- a/CC.Service.Webhost/Tools/Mapper.cs
+++ b/CC.Service.Webhost/Tools/Mapper.cs
@@ -139,6 +139,7 @@
                 Location = s.Location,
                 Speaker = s.Speaker.FirstName + " " + s.Speaker.LastName,
                 ImageUrl = s.Speaker.ImageUrl,
+                Image = s.Speaker.Image,
                 SpeakerID = s.Speaker.ID,
                 TrackID = s.Track_ID,
                 Track = s.Track == null ? "" : s.Track.Name,
@@ -166,7 +167,8 @@
                 Website = p.Website,
                 Blog = p.Blog,
                 Twitter = p.Twitter,
-                ImageUrl = p.ImageUrl
+                ImageUrl = p.ImageUrl,
+                Image = p.Image
             };
 
             foreach (var session in p.Sessions)
@@ -188,7 +190,8 @@
                 Website = p.Website,
                 Blog = p.Blog,
                 Twitter = p.Twitter,
-                ImageUrl = p.ImageUrl
+                ImageUrl = p.ImageUrl,
+                Image = p.Image
             };
 
             return person;
@@ -207,7 +210,8 @@
                 Website = p.Website,
                 Blog = p.Blog,
                 Twitter = p.Twitter,
-                ImageUrl = p.ImageUrl
+                ImageUrl = p.ImageUrl,
+                Image = p.Image
             };
 
             return person;

--- a/CC.UI.Webhost/Controllers/AdministratorController.cs
+++ b/CC.UI.Webhost/Controllers/AdministratorController.cs
@@ -28,9 +28,11 @@
                                   ID = speaker.ID,
                                   Email = speaker.Email,
                                   Twitter = speaker.Twitter,
-                                  ImageUrl = speaker.ImageUrl
-                              };
-                if (string.IsNullOrEmpty(speaker.ImageUrl)) 
+                                  ImageUrl = speaker.ImageUrl,
+                                  Image = speaker.Image
+                };
+
+                if (speaker.Image == null && string.IsNullOrEmpty(speaker.ImageUrl)) 
                 {
                     var person = service.FindPersonByEmail(sp.Email, sp.LoginProvider);
                     person.ImageUrl = GetImageInfo(person.Twitter, localImageUrl);

--- a/CC.UI.Webhost/Controllers/BaseController.cs
+++ b/CC.UI.Webhost/Controllers/BaseController.cs
@@ -79,32 +79,7 @@ namespace CC.UI.Webhost.Controllers
             return twitterUrl;
         }
 
-        //"../../Content/avatar"
-        protected string GetImageInfo(HttpPostedFileBase file, string destinationFolder)
-        {
-            string imgUrl = string.Empty;
-            var postedFile = file;
-            if (postedFile.ContentLength > 0)
-            {
-                try
-                {
-                    WebImage rewrittenImage = RewritePostedImage(file);
-                    var persistedPath = string.Format("../..{0}/{1}", destinationFolder, rewrittenImage.FileName);
-                    string fullPath = Path.Combine(Server.MapPath(destinationFolder), rewrittenImage.FileName);
-                    postedFile.SaveAs(fullPath);
-                    imgUrl = persistedPath;
-                }
-                catch (Exception e)
-                {
-                    string s = e.GetBaseException().Message;
-                    // Swallow
-                }
-
-            }
-            return imgUrl;
-        }
-
-        private WebImage RewritePostedImage(HttpPostedFileBase uploadedFile)
+        protected WebImage RewritePostedImage(HttpPostedFileBase uploadedFile)
         {
             byte[] imageArray = new byte[uploadedFile.ContentLength];
             uploadedFile.InputStream.Read(imageArray, 0, uploadedFile.ContentLength);

--- a/CC.UI.Webhost/Controllers/HomeController.cs
+++ b/CC.UI.Webhost/Controllers/HomeController.cs
@@ -90,11 +90,12 @@ namespace CC.UI.Webhost.Controllers
             foreach (var speaker in speakers)
             {
                 Speaker sp = new Speaker()
-                              {
-                                  ID = speaker.ID,
-                                  FirstName = speaker.FirstName,
-                                  LastName = speaker.LastName,
-                                  ImageUrl = speaker.ImageUrl
+                {
+                                    ID = speaker.ID,
+                                    FirstName = speaker.FirstName,
+                                    LastName = speaker.LastName,
+                                    ImageUrl = speaker.ImageUrl,
+                                    Image = speaker.Image
                               };
                 List<Session> sessions = new List<Session>();
                 foreach (var session in service.GetSpeakerSessions(eventid, sp.ID))
@@ -134,6 +135,7 @@ namespace CC.UI.Webhost.Controllers
                                       Description = session.Description,
                                       Speaker = session.Speaker,
                                       ImageUrl = session.ImageUrl,
+                                      Image = session.Image,
                                       SpeakerID = session.SpeakerID,
                                       StartTime = session.StartTime.HasValue ? session.StartTime.Value.ToString() : string.Empty,
                                       EndTime = session.EndTime.HasValue ? session.EndTime.Value.ToString() : string.Empty,
@@ -435,11 +437,9 @@ namespace CC.UI.Webhost.Controllers
                                 LastName = assignee.LastName,
                                 Email = assignee.Email,
                                 ID = assignee.ID,
-                                ImageUrl =
-                                    (String.IsNullOrEmpty(assignee.ImageUrl)
-                                         ? CONST_DEFAULT_ICON_URL
-                                         : assignee.ImageUrl)
-                            };
+                                ImageUrl = assignee.ImageUrl,
+                                Image = assignee.Image
+                    };
                     vt.Volunteers.Add(v);
                 }
             }

--- a/CC.UI.Webhost/Controllers/MetroTileController.cs
+++ b/CC.UI.Webhost/Controllers/MetroTileController.cs
@@ -60,6 +60,14 @@ namespace CC.UI.Webhost.Controllers
                         Title = string.Format("Welcome, {0}", user.FirstName)
                     };
                 }
+                else if (user.Image != null)
+                {
+                    metroTileImage = new MetroTileImage(new WebImageOCC(user.Image))
+                    {
+                        AltText = user.FullName,
+                        Title = string.Format("Welcome, {0}", user.FirstName)
+                    };
+                }
             }
             else
             {

--- a/CC.UI.Webhost/Controllers/SessionController.cs
+++ b/CC.UI.Webhost/Controllers/SessionController.cs
@@ -61,6 +61,7 @@ namespace CC.UI.Webhost.Controllers
                 Speaker = session.Speaker,
                 Status = session.Status,
                 ImageUrl = session.ImageUrl,
+                Image = session.Image,
                 StartTime = string.Format("{0}", session.StartTime.HasValue ? session.StartTime.Value.ToShortTimeString() : "N/A"),
                 EndTime = string.Format("{0}", session.EndTime.HasValue ? session.EndTime.Value.ToShortTimeString() : "N/A"),
                 Location = string.IsNullOrEmpty(session.Location) ? string.Empty : session.Location

--- a/CC.UI.Webhost/Controllers/SpeakerController.cs
+++ b/CC.UI.Webhost/Controllers/SpeakerController.cs
@@ -38,7 +38,8 @@ using System.Web.UI;
                 Website = speaker.Website,
                 Blog = speaker.Blog,
                 Twitter = speaker.Twitter,
-                ImageUrl = speaker.ImageUrl
+                ImageUrl = speaker.ImageUrl,
+                Image = speaker.Image
             };
 
             foreach (var session in speaker.Sessions)

--- a/CC.UI.Webhost/Infrastructure/HtmlExtensionHelpers.cs
+++ b/CC.UI.Webhost/Infrastructure/HtmlExtensionHelpers.cs
@@ -29,6 +29,24 @@ namespace CC.UI.Webhost.Infrastructure
             return MvcHtmlString.Create(imgHtml);
         }
 
+        public static MvcHtmlString ImageTag(this HtmlHelper html, WebImageOCC src, string alt, int? height = null, int? width = null,
+                             string title = null, string cssClass = null)
+        {
+            var imageTagBuilder = new TagBuilder("img");
+            imageTagBuilder.MergeAttribute("src", "data:image;base64," + Convert.ToBase64String(src.GetBytes()));
+            imageTagBuilder.MergeAttribute("alt", alt);
+            if (height != null && height > 0)
+                imageTagBuilder.MergeAttribute("height", height.ToString());
+            if (width != null && width > 0)
+                imageTagBuilder.MergeAttribute("width", width.ToString());
+            if (!string.IsNullOrEmpty(title))
+                imageTagBuilder.MergeAttribute("title", title);
+            if (!string.IsNullOrEmpty(cssClass))
+                imageTagBuilder.MergeAttribute("class", cssClass);
+            string imgHtml = imageTagBuilder.ToString(TagRenderMode.SelfClosing);
+
+            return MvcHtmlString.Create(imgHtml);
+        }
 
         public static MvcHtmlString ImageTag(this HtmlHelper html, MetroTileImage image, string cssClass = null)
         {

--- a/CC.UI.Webhost/Infrastructure/HtmlExtensionHelpers.cs
+++ b/CC.UI.Webhost/Infrastructure/HtmlExtensionHelpers.cs
@@ -6,15 +6,28 @@ namespace CC.UI.Webhost.Infrastructure
 {
     public static class HtmlExtensionHelpers
     {
-        public static MvcHtmlString ImageTag(this HtmlHelper html, string src, string alt, int? height = null, int? width = null,
+        public static MvcHtmlString ImageTag(this HtmlHelper html, byte[] srcImage, string srcImageUrl, string alt, int? height = null, int? width = null,
                                              string title = null, string cssClass = null)
         {
-            if (string.IsNullOrWhiteSpace(src))
-                return null;
             var url = new UrlHelper(html.ViewContext.RequestContext);
-
             var imageTagBuilder = new TagBuilder("img");
-            imageTagBuilder.MergeAttribute("src", url.Content(src));
+
+            // Use image if available.
+            if (srcImage != null)
+            {
+                imageTagBuilder.MergeAttribute("src", "data:image;base64," + Convert.ToBase64String(srcImage));
+            }
+            // Use url.
+            else
+            {
+                // Use default if not provided.
+                if (string.IsNullOrEmpty(srcImageUrl))
+                    srcImageUrl = "/Content/Avatar/default_user_icon.jpg";
+
+                // Default to url.
+                imageTagBuilder.MergeAttribute("src", url.Content(srcImageUrl));
+            }
+
             imageTagBuilder.MergeAttribute("alt", alt);
             if (height != null && height > 0)
                 imageTagBuilder.MergeAttribute("height", height.ToString());
@@ -29,28 +42,9 @@ namespace CC.UI.Webhost.Infrastructure
             return MvcHtmlString.Create(imgHtml);
         }
 
-        public static MvcHtmlString ImageTag(this HtmlHelper html, WebImageOCC src, string alt, int? height = null, int? width = null,
-                             string title = null, string cssClass = null)
-        {
-            var imageTagBuilder = new TagBuilder("img");
-            imageTagBuilder.MergeAttribute("src", "data:image;base64," + Convert.ToBase64String(src.GetBytes()));
-            imageTagBuilder.MergeAttribute("alt", alt);
-            if (height != null && height > 0)
-                imageTagBuilder.MergeAttribute("height", height.ToString());
-            if (width != null && width > 0)
-                imageTagBuilder.MergeAttribute("width", width.ToString());
-            if (!string.IsNullOrEmpty(title))
-                imageTagBuilder.MergeAttribute("title", title);
-            if (!string.IsNullOrEmpty(cssClass))
-                imageTagBuilder.MergeAttribute("class", cssClass);
-            string imgHtml = imageTagBuilder.ToString(TagRenderMode.SelfClosing);
-
-            return MvcHtmlString.Create(imgHtml);
-        }
-
         public static MvcHtmlString ImageTag(this HtmlHelper html, MetroTileImage image, string cssClass = null)
         {
-            return ImageTag(html, image.PathUri, image.AltText, image.Height, image.Width, image.Title, cssClass);
+            return ImageTag(html, null, image.PathUri, image.AltText, image.Height, image.Width, image.Title, cssClass);
         }
 
         public static MvcHtmlString TileImageTag(this HtmlHelper html, MetroTileImage image, string cssClass = null)

--- a/CC.UI.Webhost/Infrastructure/HtmlExtensionHelpers.cs
+++ b/CC.UI.Webhost/Infrastructure/HtmlExtensionHelpers.cs
@@ -14,19 +14,10 @@ namespace CC.UI.Webhost.Infrastructure
 
             // Use image if available.
             if (srcImage != null)
-            {
                 imageTagBuilder.MergeAttribute("src", "data:image;base64," + Convert.ToBase64String(srcImage));
-            }
             // Use url.
             else
-            {
-                // Use default if not provided.
-                if (string.IsNullOrEmpty(srcImageUrl))
-                    srcImageUrl = "/Content/Avatar/default_user_icon.jpg";
-
-                // Default to url.
                 imageTagBuilder.MergeAttribute("src", url.Content(srcImageUrl));
-            }
 
             imageTagBuilder.MergeAttribute("alt", alt);
             if (height != null && height > 0)
@@ -40,6 +31,12 @@ namespace CC.UI.Webhost.Infrastructure
             string imgHtml = imageTagBuilder.ToString(TagRenderMode.SelfClosing);
 
             return MvcHtmlString.Create(imgHtml);
+        }
+
+        public static MvcHtmlString AvatarImageTag(this HtmlHelper html, byte[] srcImage, string srcImageUrl, string alt, int? height = null, int? width = null,
+                                     string title = null, string cssClass = null)
+        {
+            return ImageTag(html, srcImage, !string.IsNullOrEmpty(srcImageUrl) ? srcImageUrl : "/Content/Avatar/default_user_icon.jpg", alt, height, width, title = null, cssClass = null);
         }
 
         public static MvcHtmlString ImageTag(this HtmlHelper html, MetroTileImage image, string cssClass = null)

--- a/CC.UI.Webhost/Infrastructure/HtmlExtensionHelpers.cs
+++ b/CC.UI.Webhost/Infrastructure/HtmlExtensionHelpers.cs
@@ -9,7 +9,12 @@ namespace CC.UI.Webhost.Infrastructure
         public static MvcHtmlString ImageTag(this HtmlHelper html, byte[] srcImage, string srcImageUrl, string alt, int? height = null, int? width = null,
                                              string title = null, string cssClass = null)
         {
+            // Don't return an html string for null.
+            if (string.IsNullOrWhiteSpace(srcImageUrl) && srcImage == null)
+                return null;
+
             var url = new UrlHelper(html.ViewContext.RequestContext);
+
             var imageTagBuilder = new TagBuilder("img");
 
             // Use image if available.

--- a/CC.UI.Webhost/Infrastructure/ModelExtensions.cs
+++ b/CC.UI.Webhost/Infrastructure/ModelExtensions.cs
@@ -21,6 +21,7 @@ namespace CC.UI.Webhost.Infrastructure
             {
                 ID = person.ID,
                 ImageUrl = person.ImageUrl,
+                Image = person.Image,
                 Website = person.Website,
                 Email = person.Email,
                 Bio = person.Bio,
@@ -48,6 +49,7 @@ namespace CC.UI.Webhost.Infrastructure
             {
                 ID = person.ID,
                 ImageUrl = person.ImageUrl,
+                Image = person.Image,
                 Website = person.Website,
                 Email = person.Email,
                 Bio = person.Bio,
@@ -69,6 +71,7 @@ namespace CC.UI.Webhost.Infrastructure
             {
                 ID = person.ID,
                 ImageUrl = person.ImageUrl,
+                Image = person.Image,
                 Website = person.Website,
                 Email = person.Email,
                 Bio = person.Bio,
@@ -93,6 +96,7 @@ namespace CC.UI.Webhost.Infrastructure
             var modelSpeaker = new Model.Speaker()
                                    {
                                        ImageUrl = speaker.ImageUrl,
+                                       Image = speaker.Image,
                                        Website = speaker.Website,
                                        Email = speaker.Email,
                                        Bio = speaker.Bio,

--- a/CC.UI.Webhost/Models/AccountModels.cs
+++ b/CC.UI.Webhost/Models/AccountModels.cs
@@ -10,6 +10,7 @@ namespace CC.UI.Webhost.Models
         public string DisplayFirstName { get; set; }
         public string DisplayLastName { get; set; }
         public string Avatar { get; set; }
+        public byte[] AvatarImage { get; set; }
         public bool IsLoggedIn { get; set; }
     }
 

--- a/CC.UI.Webhost/Models/Person.cs
+++ b/CC.UI.Webhost/Models/Person.cs
@@ -57,6 +57,8 @@ namespace CC.UI.Webhost.Models
 
         public string ImageUrl { get; set; }
 
+        public byte[] Image { get; set; }
+
         public bool IsAdmin { get; set; }
 
         public string FullName { get { return FirstName + " " + LastName; } }

--- a/CC.UI.Webhost/Models/Session.cs
+++ b/CC.UI.Webhost/Models/Session.cs
@@ -36,6 +36,8 @@
 
         public string ImageUrl { get; set; }
 
+        public byte[] Image { get; set; }
+
         public string StartTime { get; set; }
 
         public string EndTime { get; set; }

--- a/CC.UI.Webhost/Views/Account/ExternalLoginConfirmation.cshtml
+++ b/CC.UI.Webhost/Views/Account/ExternalLoginConfirmation.cshtml
@@ -5,7 +5,7 @@
 <h2>@ViewBag.Title.</h2>
 <h3>Associate your @ViewBag.LoginProvider account.</h3>
 
-@using (Html.BeginForm("ExternalLoginConfirmation", "Account", new { ReturnUrl = ViewBag.ReturnUrl }, FormMethod.Post, new { @class = "form-horizontal", role = "form" }))
+@using (Html.BeginForm("ExternalLoginConfirmation", "Account", new { ReturnUrl = ViewBag.ReturnUrl }, FormMethod.Post, new { @class = "form-horizontal", role = "form", enctype = "multipart/form-data" }))
 {
     @Html.AntiForgeryToken()
 

--- a/CC.UI.Webhost/Views/Home/Sessions.cshtml
+++ b/CC.UI.Webhost/Views/Home/Sessions.cshtml
@@ -41,7 +41,20 @@ else
         <div style="float: left; width: 48px">
             <a href="@Url.Action("Details", "Speaker", new { id = session.SpeakerID })">
                 <div>
-                    @Html.ImageTag(session.ImageUrl, session.Speaker, 48, 48, session.Speaker)
+                    @if (!String.IsNullOrEmpty(session.ImageUrl))
+                    {
+                        @Html.ImageTag(session.ImageUrl, session.Speaker, 48, 48, session.Speaker)
+                    }
+                    else if (session.Image != null)
+                    {
+                        @Html.ImageTag(new WebImageOCC(session.Image), session.Speaker, 48, 48, session.Speaker)
+                    }
+                    else
+                    {
+                        var defaultImgUri = "/Content/Avatar/default_user_icon.jpg";
+                        @Html.ImageTag(defaultImgUri, session.Speaker, 48, 48, session.Speaker)
+                    }
+                   @* @Html.ImageTag(session.ImageUrl, session.Speaker, 48, 48, session.Speaker)*@
                     <div style="position: relative; top: 0px; left: 0px;"><small>@session.Speaker</small>
                     </div>
                 </div>

--- a/CC.UI.Webhost/Views/Home/Sessions.cshtml
+++ b/CC.UI.Webhost/Views/Home/Sessions.cshtml
@@ -41,20 +41,7 @@ else
         <div style="float: left; width: 48px">
             <a href="@Url.Action("Details", "Speaker", new { id = session.SpeakerID })">
                 <div>
-                    @if (!String.IsNullOrEmpty(session.ImageUrl))
-                    {
-                        @Html.ImageTag(session.ImageUrl, session.Speaker, 48, 48, session.Speaker)
-                    }
-                    else if (session.Image != null)
-                    {
-                        @Html.ImageTag(new WebImageOCC(session.Image), session.Speaker, 48, 48, session.Speaker)
-                    }
-                    else
-                    {
-                        var defaultImgUri = "/Content/Avatar/default_user_icon.jpg";
-                        @Html.ImageTag(defaultImgUri, session.Speaker, 48, 48, session.Speaker)
-                    }
-                   @* @Html.ImageTag(session.ImageUrl, session.Speaker, 48, 48, session.Speaker)*@
+                    @Html.ImageTag(session.Image, session.ImageUrl, session.Speaker, 48, 48, session.Speaker)
                     <div style="position: relative; top: 0px; left: 0px;"><small>@session.Speaker</small>
                     </div>
                 </div>

--- a/CC.UI.Webhost/Views/Home/Sessions.cshtml
+++ b/CC.UI.Webhost/Views/Home/Sessions.cshtml
@@ -41,7 +41,7 @@ else
         <div style="float: left; width: 48px">
             <a href="@Url.Action("Details", "Speaker", new { id = session.SpeakerID })">
                 <div>
-                    @Html.ImageTag(session.Image, session.ImageUrl, session.Speaker, 48, 48, session.Speaker)
+                    @Html.AvatarImageTag(session.Image, session.ImageUrl, session.Speaker, 48, 48, session.Speaker)
                     <div style="position: relative; top: 0px; left: 0px;"><small>@session.Speaker</small>
                     </div>
                 </div>

--- a/CC.UI.Webhost/Views/Home/Speakers.cshtml
+++ b/CC.UI.Webhost/Views/Home/Speakers.cshtml
@@ -29,20 +29,7 @@
             <div style="float:left;width:60px">
                 <a href="@Url.Action( "Details", "Speaker", new { id = speaker.ID })">
                     <div>
-                        @if (!String.IsNullOrEmpty(speaker.ImageUrl))
-                        {
-                            @Html.ImageTag(speaker.ImageUrl, speaker.FullName, 60, 60, speaker.FullName)
-                        }
-                        else if (speaker.Image != null)
-                        {
-                            @Html.ImageTag(new WebImageOCC(speaker.Image), speaker.FullName, 60, 60, speaker.FullName)
-                        }
-                        else
-                        {
-                            var defaultImgUri = "/Content/Avatar/default_user_icon.jpg";
-                            @Html.ImageTag(defaultImgUri, speaker.FullName, 60, 60, speaker.FullName)
-                        }
-                        @*@Html.ImageTag(speaker.ImageUrl, speaker.FullName, 60, 60, speaker.FullName)*@
+                        @Html.ImageTag(speaker.Image, speaker.ImageUrl, speaker.FullName, 60, 60, speaker.FullName)
                         <div style="position: relative; top: 0px; left: 0px;">@speaker.FullName
                         </div>
                     </div>

--- a/CC.UI.Webhost/Views/Home/Speakers.cshtml
+++ b/CC.UI.Webhost/Views/Home/Speakers.cshtml
@@ -29,7 +29,7 @@
             <div style="float:left;width:60px">
                 <a href="@Url.Action( "Details", "Speaker", new { id = speaker.ID })">
                     <div>
-                        @Html.ImageTag(speaker.Image, speaker.ImageUrl, speaker.FullName, 60, 60, speaker.FullName)
+                        @Html.AvatarImageTag(speaker.Image, speaker.ImageUrl, speaker.FullName, 60, 60, speaker.FullName)
                         <div style="position: relative; top: 0px; left: 0px;">@speaker.FullName
                         </div>
                     </div>

--- a/CC.UI.Webhost/Views/Home/Speakers.cshtml
+++ b/CC.UI.Webhost/Views/Home/Speakers.cshtml
@@ -29,8 +29,21 @@
             <div style="float:left;width:60px">
                 <a href="@Url.Action( "Details", "Speaker", new { id = speaker.ID })">
                     <div>
-                        @Html.ImageTag(speaker.ImageUrl, speaker.FullName, 60, 60, speaker.FullName)
-                        <div style="position:relative;top:0px;left:0px;">@speaker.FullName
+                        @if (!String.IsNullOrEmpty(speaker.ImageUrl))
+                        {
+                            @Html.ImageTag(speaker.ImageUrl, speaker.FullName, 60, 60, speaker.FullName)
+                        }
+                        else if (speaker.Image != null)
+                        {
+                            @Html.ImageTag(new WebImageOCC(speaker.Image), speaker.FullName, 60, 60, speaker.FullName)
+                        }
+                        else
+                        {
+                            var defaultImgUri = "/Content/Avatar/default_user_icon.jpg";
+                            @Html.ImageTag(defaultImgUri, speaker.FullName, 60, 60, speaker.FullName)
+                        }
+                        @*@Html.ImageTag(speaker.ImageUrl, speaker.FullName, 60, 60, speaker.FullName)*@
+                        <div style="position: relative; top: 0px; left: 0px;">@speaker.FullName
                         </div>
                     </div>
                 </a>

--- a/CC.UI.Webhost/Views/Home/Volunteers.cshtml
+++ b/CC.UI.Webhost/Views/Home/Volunteers.cshtml
@@ -59,7 +59,7 @@
                 @foreach (var volunteer in task.Volunteers)
                 {
                     <ul>
-                        <li>@Html.ImageTag(volunteer.Image, volunteer.ImageUrl, string.Empty, 50, 50) &nbsp; @volunteer.FirstName @volunteer.LastName</li>
+                        <li>@Html.AvatarImageTag(volunteer.Image, volunteer.ImageUrl, string.Empty, 50, 50) &nbsp; @volunteer.FirstName @volunteer.LastName</li>
                    </ul>
                 }
         </div>

--- a/CC.UI.Webhost/Views/Home/Volunteers.cshtml
+++ b/CC.UI.Webhost/Views/Home/Volunteers.cshtml
@@ -56,14 +56,23 @@
             </div>
             <br/>
             <h6>Current Volunteers</h6>
-            
                 @foreach (var volunteer in task.Volunteers)
                 {
-                    var defaultImgUri = "/Content/Avatar/default_user_icon.jpg";
-                    var imgUri = (String.IsNullOrEmpty(volunteer.ImageUrl) ? defaultImgUri : volunteer.ImageUrl);
                     <ul>
-                        <li>@Html.ImageTag(imgUri, string.Empty, 50, 50) &nbsp; @volunteer.FirstName @volunteer.LastName</li>
-                    </ul>
+                        @if (!String.IsNullOrEmpty(volunteer.ImageUrl))
+                        { 
+                            <li>@Html.ImageTag(volunteer.ImageUrl, string.Empty, 50, 50) &nbsp; @volunteer.FirstName @volunteer.LastName</li>
+                        }
+                        else if (volunteer.Image != null)
+                        {
+                            <li>@Html.ImageTag(new WebImageOCC(volunteer.Image), string.Empty, 50, 50) &nbsp; @volunteer.FirstName @volunteer.LastName</li>
+                        }
+                        else
+                        {
+                            var defaultImgUri = "/Content/Avatar/default_user_icon.jpg";
+                            <li>@Html.ImageTag(defaultImgUri, string.Empty, 50, 50) &nbsp; @volunteer.FirstName @volunteer.LastName</li>
+                        }
+                   </ul>
                 }
         </div>
     }

--- a/CC.UI.Webhost/Views/Home/Volunteers.cshtml
+++ b/CC.UI.Webhost/Views/Home/Volunteers.cshtml
@@ -59,19 +59,7 @@
                 @foreach (var volunteer in task.Volunteers)
                 {
                     <ul>
-                        @if (!String.IsNullOrEmpty(volunteer.ImageUrl))
-                        { 
-                            <li>@Html.ImageTag(volunteer.ImageUrl, string.Empty, 50, 50) &nbsp; @volunteer.FirstName @volunteer.LastName</li>
-                        }
-                        else if (volunteer.Image != null)
-                        {
-                            <li>@Html.ImageTag(new WebImageOCC(volunteer.Image), string.Empty, 50, 50) &nbsp; @volunteer.FirstName @volunteer.LastName</li>
-                        }
-                        else
-                        {
-                            var defaultImgUri = "/Content/Avatar/default_user_icon.jpg";
-                            <li>@Html.ImageTag(defaultImgUri, string.Empty, 50, 50) &nbsp; @volunteer.FirstName @volunteer.LastName</li>
-                        }
+                        <li>@Html.ImageTag(volunteer.Image, volunteer.ImageUrl, string.Empty, 50, 50) &nbsp; @volunteer.FirstName @volunteer.LastName</li>
                    </ul>
                 }
         </div>

--- a/CC.UI.Webhost/Views/Session/Details.cshtml
+++ b/CC.UI.Webhost/Views/Session/Details.cshtml
@@ -20,7 +20,7 @@
 			<div class="field-value">
 				<a href="@Url.Action( "Details", "Speaker", new { id = ViewData.Model.SpeakerID })">
 				    <div>
-                        @Html.ImageTag(ViewData.Model.Image, ViewData.Model.ImageUrl, ViewData.Model.Speaker, 60, 60, ViewData.Model.Speaker)
+                        @Html.AvatarImageTag(ViewData.Model.Image, ViewData.Model.ImageUrl, ViewData.Model.Speaker, 60, 60, ViewData.Model.Speaker)
 				        <div style="position: relative; top: 0px; left: 0px;">@ViewData.Model.Speaker
 				        </div>
 				    </div>

--- a/CC.UI.Webhost/Views/Session/Details.cshtml
+++ b/CC.UI.Webhost/Views/Session/Details.cshtml
@@ -20,19 +20,7 @@
 			<div class="field-value">
 				<a href="@Url.Action( "Details", "Speaker", new { id = ViewData.Model.SpeakerID })">
 				    <div>
-                        @if (!String.IsNullOrEmpty(ViewData.Model.ImageUrl))
-                        {
-                            @Html.ImageTag(ViewData.Model.ImageUrl, ViewData.Model.Speaker, 60, 60, ViewData.Model.Speaker)
-                        }
-                        else if (ViewData.Model.Image != null)
-                        {
-                            @Html.ImageTag(new WebImageOCC(ViewData.Model.Image), ViewData.Model.Speaker, 60, 60, ViewData.Model.Speaker)
-                        }
-                        else
-                        {
-                            var defaultImgUri = "/Content/Avatar/default_user_icon.jpg";
-                            @Html.ImageTag(defaultImgUri, ViewData.Model.Speaker, 60, 60, ViewData.Model.Speaker)
-                        }
+                        @Html.ImageTag(ViewData.Model.Image, ViewData.Model.ImageUrl, ViewData.Model.Speaker, 60, 60, ViewData.Model.Speaker)
 				        <div style="position: relative; top: 0px; left: 0px;">@ViewData.Model.Speaker
 				        </div>
 				    </div>

--- a/CC.UI.Webhost/Views/Session/Details.cshtml
+++ b/CC.UI.Webhost/Views/Session/Details.cshtml
@@ -19,11 +19,23 @@
 
 			<div class="field-value">
 				<a href="@Url.Action( "Details", "Speaker", new { id = ViewData.Model.SpeakerID })">
-					<div>
-						@Html.ImageTag(ViewData.Model.ImageUrl, ViewData.Model.Speaker, 60, 60, ViewData.Model.Speaker)
-						<div style="position:relative;top:0px;left:0px;">@ViewData.Model.Speaker
-						</div>
-					</div>
+				    <div>
+                        @if (!String.IsNullOrEmpty(ViewData.Model.ImageUrl))
+                        {
+                            @Html.ImageTag(ViewData.Model.ImageUrl, ViewData.Model.Speaker, 60, 60, ViewData.Model.Speaker)
+                        }
+                        else if (ViewData.Model.Image != null)
+                        {
+                            @Html.ImageTag(new WebImageOCC(ViewData.Model.Image), ViewData.Model.Speaker, 60, 60, ViewData.Model.Speaker)
+                        }
+                        else
+                        {
+                            var defaultImgUri = "/Content/Avatar/default_user_icon.jpg";
+                            @Html.ImageTag(defaultImgUri, ViewData.Model.Speaker, 60, 60, ViewData.Model.Speaker)
+                        }
+				        <div style="position: relative; top: 0px; left: 0px;">@ViewData.Model.Speaker
+				        </div>
+				    </div>
 				</a>
 			</div>
 @if (!string.IsNullOrEmpty(ViewData.Model.Location))

--- a/CC.UI.Webhost/Views/Shared/_Layout.Responsive.cshtml
+++ b/CC.UI.Webhost/Views/Shared/_Layout.Responsive.cshtml
@@ -42,7 +42,7 @@
     <div class="siteContainer">
         <div class="left-col">
             <div id="header">
-                <a href="@Url.Action("Index", "Home")">@Html.ImageTag("../../Content/themes/Metro/Images/SCCLogo.png", "Seattle Code Camp", title: "Seattle Code Camp")</a>
+                <a href="@Url.Action("Index", "Home")">@Html.ImageTag(null, "../../Content/themes/Metro/Images/SCCLogo.png", "Seattle Code Camp", title: "Seattle Code Camp")</a>
 
                 @Html.Action("UserDisplayProfile", "Account")
             </div>

--- a/CC.UI.Webhost/Views/Shared/_Layout.WideScreen.cshtml
+++ b/CC.UI.Webhost/Views/Shared/_Layout.WideScreen.cshtml
@@ -25,7 +25,7 @@
 <body>
 <div class="scheduleContainer siteContainer">
     <div id="header">
-        <a href="@Url.Action("Index", "Home")">@Html.ImageTag("../../Content/themes/Metro/Images/SCCLogo.png", "Seattle Code Camp", title: "Seattle Code Camp")</a>
+        <a href="@Url.Action("Index", "Home")">@Html.ImageTag(null, "../../Content/themes/Metro/Images/SCCLogo.png", "Seattle Code Camp", title: "Seattle Code Camp")</a>
     </div>
 
     <div class="scheduleContainer">

--- a/CC.UI.Webhost/Views/Shared/_Layout.cshtml
+++ b/CC.UI.Webhost/Views/Shared/_Layout.cshtml
@@ -33,7 +33,7 @@
 <body>
 <div class="container_12 siteContainer">
     <div id="header" class="grid_8">
-        <a href="@Url.Action("Index", "Home")">@Html.ImageTag("../../Content/themes/Metro/Images/SCCLogo.png", "Seattle Code Camp", title: "Seattle Code Camp")</a>
+        <a href="@Url.Action("Index", "Home")">@Html.ImageTag(null, "../../Content/themes/Metro/Images/SCCLogo.png", "Seattle Code Camp", title: "Seattle Code Camp")</a>
     </div>
     <div id="tilesColumnRight" class="tilesArea">
         @Html.Action("UserDisplayProfile", "Account")

--- a/CC.UI.Webhost/Views/Shared/_UserDisplayProfile.cshtml
+++ b/CC.UI.Webhost/Views/Shared/_UserDisplayProfile.cshtml
@@ -16,6 +16,13 @@
                     {
                         @Html.ImageTag(Model.Avatar, string.Format("{0} {1}", Model.DisplayFirstName, Model.DisplayLastName), 48, 48)
                     }
+                    else
+                    {
+                        if (Model.AvatarImage != null)
+                        {
+                            @Html.ImageTag(new WebImageOCC(Model.AvatarImage), string.Format("{0} {1}", Model.DisplayFirstName, Model.DisplayLastName), 48, 48)
+                        }
+                    }
                 </a>
             </div>
             @* <p><a href="@Url.Action("LogOff", "Account")">Logout</a> / <a class="loginDisplayArea" href="@Url.Action("FAQ", "Home")">F.A.Q.</a></p>*@

--- a/CC.UI.Webhost/Views/Shared/_UserDisplayProfile.cshtml
+++ b/CC.UI.Webhost/Views/Shared/_UserDisplayProfile.cshtml
@@ -12,7 +12,7 @@
             </div>
             <div class="avatarImage">
                 <a href="@Url.Action("UpdateProfile", "Account")">
-                    @Html.ImageTag(Model.AvatarImage, Model.Avatar, string.Format("{0} {1}", Model.DisplayFirstName, Model.DisplayLastName), 48, 48)
+                    @Html.AvatarImageTag(Model.AvatarImage, Model.Avatar, string.Format("{0} {1}", Model.DisplayFirstName, Model.DisplayLastName), 48, 48)
                 </a>
             </div>
             <div class="loginDisplayContainer">

--- a/CC.UI.Webhost/Views/Shared/_UserDisplayProfile.cshtml
+++ b/CC.UI.Webhost/Views/Shared/_UserDisplayProfile.cshtml
@@ -12,20 +12,9 @@
             </div>
             <div class="avatarImage">
                 <a href="@Url.Action("UpdateProfile", "Account")">
-                    @if (Model.Avatar != null)
-                    {
-                        @Html.ImageTag(Model.Avatar, string.Format("{0} {1}", Model.DisplayFirstName, Model.DisplayLastName), 48, 48)
-                    }
-                    else
-                    {
-                        if (Model.AvatarImage != null)
-                        {
-                            @Html.ImageTag(new WebImageOCC(Model.AvatarImage), string.Format("{0} {1}", Model.DisplayFirstName, Model.DisplayLastName), 48, 48)
-                        }
-                    }
+                    @Html.ImageTag(Model.AvatarImage, Model.Avatar, string.Format("{0} {1}", Model.DisplayFirstName, Model.DisplayLastName), 48, 48)
                 </a>
             </div>
-            @* <p><a href="@Url.Action("LogOff", "Account")">Logout</a> / <a class="loginDisplayArea" href="@Url.Action("FAQ", "Home")">F.A.Q.</a></p>*@
             <div class="loginDisplayContainer">
                 <a class="loginDisplayArea" href="@Url.Action("LogOff", "Account")"><h6>Logout</h6></a>
             </div>

--- a/CC.UI.Webhost/Views/Speaker/Details.cshtml
+++ b/CC.UI.Webhost/Views/Speaker/Details.cshtml
@@ -10,7 +10,7 @@
 
 <div class="field-value">
     <div style="width: 250px">
-        @Html.ImageTag(ViewData.Model.Image, ViewData.Model.ImageUrl, ViewData.Model.FullName)
+        @Html.AvatarImageTag(ViewData.Model.Image, ViewData.Model.ImageUrl, ViewData.Model.FullName)
     </div>
 </div>
 

--- a/CC.UI.Webhost/Views/Speaker/Details.cshtml
+++ b/CC.UI.Webhost/Views/Speaker/Details.cshtml
@@ -9,9 +9,21 @@
 <div class="title">speaker</div>
 
 <div class="field-value">
-<div style="width:250px">
-<img style="max-width: 100%;" src="@ViewData.Model.ImageUrl" alt="@ViewData.Model.FullName" />
-</div>
+    <div style="width: 250px">
+        @if (!String.IsNullOrEmpty(ViewData.Model.ImageUrl))
+        {
+            @Html.ImageTag(ViewData.Model.ImageUrl, ViewData.Model.FullName);
+        }
+        else if (ViewData.Model.Image != null)
+        {
+            @Html.ImageTag(new WebImageOCC(ViewData.Model.Image), ViewData.Model.FullName);
+        }
+        else
+        {
+            var defaultImgUri = "/Content/Avatar/default_user_icon.jpg";
+            @Html.ImageTag(defaultImgUri, ViewData.Model.FullName);
+        }
+    </div>
 </div>
 
 

--- a/CC.UI.Webhost/Views/Speaker/Details.cshtml
+++ b/CC.UI.Webhost/Views/Speaker/Details.cshtml
@@ -10,19 +10,7 @@
 
 <div class="field-value">
     <div style="width: 250px">
-        @if (!String.IsNullOrEmpty(ViewData.Model.ImageUrl))
-        {
-            @Html.ImageTag(ViewData.Model.ImageUrl, ViewData.Model.FullName);
-        }
-        else if (ViewData.Model.Image != null)
-        {
-            @Html.ImageTag(new WebImageOCC(ViewData.Model.Image), ViewData.Model.FullName);
-        }
-        else
-        {
-            var defaultImgUri = "/Content/Avatar/default_user_icon.jpg";
-            @Html.ImageTag(defaultImgUri, ViewData.Model.FullName);
-        }
+        @Html.ImageTag(ViewData.Model.Image, ViewData.Model.ImageUrl, ViewData.Model.FullName)
     </div>
 </div>
 


### PR DESCRIPTION
When the user uploads an image, the image is now stored in the database instead of being stored on the file system and linked. Note that this includes the default image which is still used if no twitter Url is provided and no image is uploaded.

A link is still used for users which specify a twitter URL.
An 'Image' property was added to all objects that already contain an ImageURL property. The code decides what to use/show depending on the value of these properties. Generally the Image property takes precedence if available.

Existing users whose image was previously stored on the file system and is now lost will need to re-upload their image in order for it to be stored/used correctly by the new site.

In conjunction with this change some parts of the code that previously would not show anything in the case that no image is available will now show the default image, other than this there is no visible UI changes for this fix.

Related Bug Fix: The external login page now handles uploaded avatar images correctly, previously an uploaded image file would be ignored & the default or twitter image (if specified) would be used.