### PR TITLE
added missing Image column to People table in create script and added session location to My Agenda page

### DIFF
--- a/CC.Data.Database/SetupScripts/Create.sql
+++ b/CC.Data.Database/SetupScripts/Create.sql
@@ -123,6 +123,7 @@ CREATE TABLE [dbo].[People] (
     [Location]      NVARCHAR (100)  NULL,
     [TShirtSize]    INT             NULL,
     [LoginProvider] NVARCHAR (128)  NULL,
+    [Image]         VARBINARY (MAX) NULL,
     CONSTRAINT [PK__People__3214EC2714FCD345] PRIMARY KEY CLUSTERED ([ID] ASC)
 );
 

--- a/CC.UI.Webhost/Views/Home/MyAgenda.cshtml
+++ b/CC.UI.Webhost/Views/Home/MyAgenda.cshtml
@@ -21,6 +21,8 @@
     <tr>
         <td>Time</td>
         <td>&nbsp;&nbsp;&nbsp;</td>
+        <td>Location</td>
+        <td>&nbsp;&nbsp;&nbsp;</td>
         <td>Session</td>
         <td>&nbsp;&nbsp;&nbsp;</td>
         <td>Speaker</td>
@@ -33,6 +35,10 @@
         <tr>
             <td nowrap="nowrap">
                 <div style="font-size: small">@session.StartTime - @session.EndTime</div>
+            </td>
+            <td>&nbsp;&nbsp;&nbsp;</td>
+            <td>
+                <div style="font-size: small">@session.Location</div>
             </td>
             <td>&nbsp;&nbsp;&nbsp;</td>
             <td>


### PR DESCRIPTION
The Image column in the People table was missing from the setup script and added the session location to the My Agenda page.